### PR TITLE
feat: expose structured ledger in evaluation

### DIFF
--- a/backend/evaluate_chart.py
+++ b/backend/evaluate_chart.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Dict
+from pathlib import Path
+import sys
+
+# Ensure repository root on path when executed directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from backend.category_router import get_contract
 from backend.horary_engine.engine import extract_testimonies
@@ -25,7 +30,36 @@ def evaluate_chart(chart: Dict[str, Any]) -> Dict[str, Any]:
     contract = get_contract(chart.get("category", ""))
     testimonies = extract_testimonies(chart, contract)
     score, ledger = aggregate(testimonies)
-    logger.debug("Contribution ledger: %s", ledger)
+    # Surface ledger details for downstream inspection and debugging
+    logger.info("Contribution ledger: %s", ledger)
     rationale = build_rationale(ledger)
     verdict = "YES" if score > 0 else "NO"
     return {"verdict": verdict, "ledger": ledger, "rationale": rationale}
+
+
+if __name__ == "__main__":
+    """Allow command-line evaluation of charts.
+
+    When executed directly, the module accepts an optional path to a chart JSON
+    file. If no path is provided, it defaults to the AE-015 sample chart.
+    The resulting ledger is printed for inspection.
+    """
+    import argparse
+    import json
+    from pathlib import Path
+
+    default_chart = Path(__file__).resolve().parent / (
+        "e AE-015 – “Will I pass my physiotherapy exam.json"
+    )
+    parser = argparse.ArgumentParser(description="Evaluate a horary chart")
+    parser.add_argument(
+        "chart_path",
+        nargs="?",
+        default=str(default_chart),
+        help="Path to chart JSON file",
+    )
+    args = parser.parse_args()
+
+    chart_data = json.loads(Path(args.chart_path).read_text(encoding="utf-8"))
+    result = evaluate_chart(chart_data)
+    print(json.dumps(result["ledger"], indent=2))

--- a/backend/horary_engine/rationale.py
+++ b/backend/horary_engine/rationale.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 from typing import List, Dict
 
 
-def build_rationale(ledger: List[Dict[str, float]]) -> List[str]:
+def build_rationale(ledger: List[Dict[str, float | str]]) -> List[str]:
     """Create a rationale list from a contribution ledger.
 
     The function is pure and does not mutate the input ledger.
     """
     result: List[str] = []
     for entry in ledger:
-        token = entry.get("token", "")
+        key = entry.get("key", "")
         weight = entry.get("weight", 0.0)
         polarity = entry.get("polarity", 0)
         sign = "+" if polarity >= 0 else "-"
-        result.append(f"{token} {sign}{weight}")
+        result.append(f"{key} {sign}{weight}")
     return result

--- a/tests/test_aggregator_properties.py
+++ b/tests/test_aggregator_properties.py
@@ -10,8 +10,11 @@ NEG = "moon_applying_square_examiner_sun"
 
 
 def test_polars_and_monotonicity():
-    score_pos, _ = aggregate([POS])
+    score_pos, ledger_pos = aggregate([POS])
     assert score_pos > 0
+    entry_pos = ledger_pos[0]
+    assert entry_pos["key"] == POS
+    assert entry_pos["delta_yes"] > 0 and entry_pos["delta_no"] == 0
     # Duplicate contributions do not increase score
     score_dup, _ = aggregate([POS, POS])
     assert score_dup == score_pos
@@ -19,5 +22,7 @@ def test_polars_and_monotonicity():
     score_both, _ = aggregate([POS, NEG])
     assert score_both < score_pos
 
-    score_neg, _ = aggregate([NEG])
+    score_neg, ledger_neg = aggregate([NEG])
     assert score_neg < 0
+    entry_neg = ledger_neg[0]
+    assert entry_neg["delta_no"] > 0 and entry_neg["delta_yes"] == 0

--- a/tests/test_golden_ae015.py
+++ b/tests/test_golden_ae015.py
@@ -14,5 +14,5 @@ def test_ae015_golden_expect_yes():
     chart = json.loads(data_path.read_text(encoding="utf-8"))
     result = evaluate_chart(chart)
     assert result["verdict"] == "YES"
-    tokens = [entry["token"] for entry in result["ledger"]]
-    assert "moon_applying_trine_examiner_sun" in tokens
+    keys = [entry["key"] for entry in result["ledger"]]
+    assert "moon_applying_trine_examiner_sun" in keys


### PR DESCRIPTION
## Summary
- extend aggregator to report `key`, `polarity`, `weight`, `delta_yes`, and `delta_no`
- log contribution ledger and add CLI entry point for chart evaluation
- adjust rationale builder and tests for new ledger shape

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a156f22f2c8324a1a9e4083a73c925