### PR TITLE
Use enums for testimony polarity and keys

### DIFF
--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -39,12 +39,15 @@ from .services.geolocation import (
     LocationError,
     safe_geocode,
 )
+from .polarity_weights import TestimonyKey
 
 # Setup module logger
 logger = logging.getLogger(__name__)
 
 
-def extract_testimonies(chart: Dict[str, Any], contract: Dict[str, str]) -> List[str]:
+def extract_testimonies(
+    chart: Dict[str, Any], contract: Dict[str, str]
+) -> List[TestimonyKey]:
     """Extract normalized testimonies from a chart using category contract.
 
     Parameters
@@ -57,12 +60,12 @@ def extract_testimonies(chart: Dict[str, Any], contract: Dict[str, str]) -> List
 
     Returns
     -------
-    List[str]
-        Unique testimony tokens such as ``moon_applying_trine_examiner_sun``.
+    List[TestimonyKey]
+        Unique testimony tokens such as ``TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN``.
     """
 
-    testimonies: List[str] = []
-    seen_testimonies: set[str] = set()
+    testimonies: List[TestimonyKey] = []
+    seen_testimonies: set[TestimonyKey] = set()
     aspects = chart.get("aspects", [])
     examiner = (contract or {}).get("examiner")
 
@@ -73,7 +76,11 @@ def extract_testimonies(chart: Dict[str, Any], contract: Dict[str, str]) -> List
         p2 = aspect.get("planet2")
         aspect_name = aspect.get("aspect", "").lower()
         if examiner and ((p1 == "Moon" and p2 == examiner) or (p2 == "Moon" and p1 == examiner)):
-            token = f"moon_applying_{aspect_name}_examiner_{examiner.lower()}"
+            token_str = f"moon_applying_{aspect_name}_examiner_{examiner.lower()}"
+            try:
+                token = TestimonyKey(token_str)
+            except ValueError:
+                continue
             if token not in seen_testimonies:
                 testimonies.append(token)
                 seen_testimonies.add(token)

--- a/backend/horary_engine/polarity_weights.py
+++ b/backend/horary_engine/polarity_weights.py
@@ -1,13 +1,38 @@
 """Central repository for testimony polarity and weight tables."""
 
-POLARITY_TABLE = {
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class Polarity(Enum):
+    """Enum representing whether a testimony helps or harms the question."""
+
+    FAVORABLE = auto()
+    UNFAVORABLE = auto()
+    NEUTRAL = auto()
+
+
+class TestimonyKey(Enum):
+    """Canonical keys for all supported testimony tokens."""
+
+    MOON_APPLYING_TRINE_EXAMINER_SUN = "moon_applying_trine_examiner_sun"
+    MOON_APPLYING_SQUARE_EXAMINER_SUN = "moon_applying_square_examiner_sun"
+
+
+# Prevent pytest from collecting the enum as a test class
+TestimonyKey.__test__ = False
+
+
+POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     # Favorable Moon applying trine to the examiner (Sun in education questions)
-    "moon_applying_trine_examiner_sun": 1,
+    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: Polarity.FAVORABLE,
     # Example negative testimony
-    "moon_applying_square_examiner_sun": -1,
+    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: Polarity.UNFAVORABLE,
 }
 
-WEIGHT_TABLE = {
-    "moon_applying_trine_examiner_sun": 1.0,
-    "moon_applying_square_examiner_sun": 1.0,
+WEIGHT_TABLE: dict[TestimonyKey, float] = {
+    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: 1.0,
+    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: 1.0,
 }
+

--- a/backend/horary_engine/rationale.py
+++ b/backend/horary_engine/rationale.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 from typing import List, Dict
 
+from .polarity_weights import Polarity
 
-def build_rationale(ledger: List[Dict[str, float | str]]) -> List[str]:
+
+def build_rationale(ledger: List[Dict[str, float | str | Polarity]]) -> List[str]:
     """Create a rationale list from a contribution ledger.
 
     The function is pure and does not mutate the input ledger.
@@ -13,7 +15,12 @@ def build_rationale(ledger: List[Dict[str, float | str]]) -> List[str]:
     for entry in ledger:
         key = entry.get("key", "")
         weight = entry.get("weight", 0.0)
-        polarity = entry.get("polarity", 0)
-        sign = "+" if polarity >= 0 else "-"
+        polarity = entry.get("polarity", Polarity.NEUTRAL)
+        if polarity is Polarity.FAVORABLE:
+            sign = "+"
+        elif polarity is Polarity.UNFAVORABLE:
+            sign = "-"
+        else:
+            sign = ""
         result.append(f"{key} {sign}{weight}")
     return result

--- a/tests/test_aggregator_properties.py
+++ b/tests/test_aggregator_properties.py
@@ -1,19 +1,23 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+sys.path.append(str(repo_root / "backend"))
 
 from backend.horary_engine.aggregator import aggregate
+from backend.horary_engine.polarity_weights import TestimonyKey, Polarity
 
-POS = "moon_applying_trine_examiner_sun"
-NEG = "moon_applying_square_examiner_sun"
+POS = TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN
+NEG = TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN
 
 
 def test_polars_and_monotonicity():
     score_pos, ledger_pos = aggregate([POS])
     assert score_pos > 0
     entry_pos = ledger_pos[0]
-    assert entry_pos["key"] == POS
+    assert entry_pos["key"] == POS.value
+    assert entry_pos["polarity"] is Polarity.FAVORABLE
     assert entry_pos["delta_yes"] > 0 and entry_pos["delta_no"] == 0
     # Duplicate contributions do not increase score
     score_dup, _ = aggregate([POS, POS])
@@ -25,4 +29,5 @@ def test_polars_and_monotonicity():
     score_neg, ledger_neg = aggregate([NEG])
     assert score_neg < 0
     entry_neg = ledger_neg[0]
+    assert entry_neg["polarity"] is Polarity.UNFAVORABLE
     assert entry_neg["delta_no"] > 0 and entry_neg["delta_yes"] == 0


### PR DESCRIPTION
## Summary
- introduce `Polarity` and `TestimonyKey` enums for testimony handling
- update aggregator and rationale to consume enums
- adapt extractor and tests to new enum-based API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15df6ba208324889154f26488435c