### PR TITLE
Emit enums from testimony extraction

### DIFF
--- a/backend/category_router.py
+++ b/backend/category_router.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 from typing import Dict
 
-_CONTRACTS: Dict[str, Dict[str, str]] = {
-    "education": {"examiner": "Sun"},
+from backend.models import Planet
+
+_CONTRACTS: Dict[str, Dict[str, Planet]] = {
+    "education": {"examiner": Planet.SUN},
 }
 
 
-def get_contract(category: str) -> Dict[str, str]:
+def get_contract(category: str) -> Dict[str, Planet]:
     """Return role contract for a given category (case-insensitive)."""
     if not category:
         return {}

--- a/backend/evaluate_chart.py
+++ b/backend/evaluate_chart.py
@@ -13,6 +13,7 @@ from backend.category_router import get_contract
 from backend.horary_engine.engine import extract_testimonies
 from backend.horary_engine.aggregator import aggregate
 from backend.horary_engine.rationale import build_rationale
+from backend.horary_engine.utils import token_to_string
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,13 @@ def evaluate_chart(chart: Dict[str, Any]) -> Dict[str, Any]:
     testimonies = extract_testimonies(chart, contract)
     score, ledger = aggregate(testimonies)
     # Surface ledger details for downstream inspection and debugging
-    logger.info("Contribution ledger: %s", ledger)
+    logger.info(
+        "Contribution ledger: %s",
+        [
+            {**entry, "key": token_to_string(entry.get("key"))}
+            for entry in ledger
+        ],
+    )
     rationale = build_rationale(ledger)
     verdict = "YES" if score > 0 else "NO"
     return {"verdict": verdict, "ledger": ledger, "rationale": rationale}

--- a/backend/horary_engine/aggregator.py
+++ b/backend/horary_engine/aggregator.py
@@ -28,7 +28,7 @@ def _coerce_tokens(testimonies: Iterable[TestimonyKey | str]) -> Sequence[Testim
 
 def aggregate(
     testimonies: Iterable[TestimonyKey | str],
-) -> Tuple[float, List[Dict[str, float | str | Polarity]]]:
+) -> Tuple[float, List[Dict[str, float | TestimonyKey | Polarity]]]:
     """Aggregate testimony tokens into a weighted score and ledger.
 
     The aggregator is *symmetric* in that positive and negative testimonies are
@@ -44,7 +44,7 @@ def aggregate(
 
     total_yes = 0.0
     total_no = 0.0
-    ledger: List[Dict[str, float | str | Polarity]] = []
+    ledger: List[Dict[str, float | TestimonyKey | Polarity]] = []
     seen: set[TestimonyKey] = set()
 
     tokens = _coerce_tokens(testimonies)
@@ -64,7 +64,7 @@ def aggregate(
         total_no += delta_no
         ledger.append(
             {
-                "key": token.value,
+                "key": token,
                 "polarity": polarity,
                 "weight": weight,
                 "delta_yes": delta_yes,

--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -40,13 +40,14 @@ from .services.geolocation import (
     safe_geocode,
 )
 from .polarity_weights import TestimonyKey
+from models import Planet
 
 # Setup module logger
 logger = logging.getLogger(__name__)
 
 
 def extract_testimonies(
-    chart: Dict[str, Any], contract: Dict[str, str]
+    chart: Dict[str, Any], contract: Dict[str, Planet]
 ) -> List[TestimonyKey]:
     """Extract normalized testimonies from a chart using category contract.
 
@@ -54,7 +55,7 @@ def extract_testimonies(
     ----------
     chart : Dict[str, Any]
         Chart data containing an ``aspects`` list.
-    contract : Dict[str, str]
+    contract : Dict[str, Planet]
         Mapping of role names to planets. Only the ``examiner`` role is
         currently supported.
 
@@ -75,8 +76,13 @@ def extract_testimonies(
         p1 = aspect.get("planet1")
         p2 = aspect.get("planet2")
         aspect_name = aspect.get("aspect", "").lower()
-        if examiner and ((p1 == "Moon" and p2 == examiner) or (p2 == "Moon" and p1 == examiner)):
-            token_str = f"moon_applying_{aspect_name}_examiner_{examiner.lower()}"
+        if examiner and (
+            (p1 == "Moon" and p2 == examiner.value)
+            or (p2 == "Moon" and p1 == examiner.value)
+        ):
+            token_str = (
+                f"moon_applying_{aspect_name}_examiner_{examiner.value.lower()}"
+            )
             try:
                 token = TestimonyKey(token_str)
             except ValueError:

--- a/backend/horary_engine/rationale.py
+++ b/backend/horary_engine/rationale.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 
 from typing import List, Dict
 
-from .polarity_weights import Polarity
+from .polarity_weights import Polarity, TestimonyKey
+from .utils import token_to_string
 
 
-def build_rationale(ledger: List[Dict[str, float | str | Polarity]]) -> List[str]:
+def build_rationale(
+    ledger: List[Dict[str, float | TestimonyKey | Polarity]]
+) -> List[str]:
     """Create a rationale list from a contribution ledger.
 
     The function is pure and does not mutate the input ledger.
     """
     result: List[str] = []
     for entry in ledger:
-        key = entry.get("key", "")
+        key = token_to_string(entry.get("key", ""))
         weight = entry.get("weight", 0.0)
         polarity = entry.get("polarity", Polarity.NEUTRAL)
         if polarity is Polarity.FAVORABLE:

--- a/backend/horary_engine/utils.py
+++ b/backend/horary_engine/utils.py
@@ -1,0 +1,21 @@
+"""Miscellaneous utility helpers for the horary engine."""
+from __future__ import annotations
+
+from typing import Union
+
+from .polarity_weights import TestimonyKey
+
+
+def token_to_string(token: Union[TestimonyKey, str]) -> str:
+    """Return a stable string representation of a testimony key.
+
+    Parameters
+    ----------
+    token:
+        Either a ``TestimonyKey`` enum member or a raw string.  The function
+        is forgiving and will simply ``str()`` any non-enum input, making it
+        safe for logging or JSON serialisation.
+    """
+    if isinstance(token, TestimonyKey):
+        return token.value
+    return str(token)

--- a/tests/test_aggregator_properties.py
+++ b/tests/test_aggregator_properties.py
@@ -16,7 +16,7 @@ def test_polars_and_monotonicity():
     score_pos, ledger_pos = aggregate([POS])
     assert score_pos > 0
     entry_pos = ledger_pos[0]
-    assert entry_pos["key"] == POS.value
+    assert entry_pos["key"] is POS
     assert entry_pos["polarity"] is Polarity.FAVORABLE
     assert entry_pos["delta_yes"] > 0 and entry_pos["delta_no"] == 0
     # Duplicate contributions do not increase score
@@ -29,5 +29,6 @@ def test_polars_and_monotonicity():
     score_neg, ledger_neg = aggregate([NEG])
     assert score_neg < 0
     entry_neg = ledger_neg[0]
+    assert entry_neg["key"] is NEG
     assert entry_neg["polarity"] is Polarity.UNFAVORABLE
     assert entry_neg["delta_no"] > 0 and entry_neg["delta_yes"] == 0

--- a/tests/test_golden_ae015.py
+++ b/tests/test_golden_ae015.py
@@ -7,6 +7,7 @@ import sys
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from backend.evaluate_chart import evaluate_chart
+from backend.horary_engine.polarity_weights import TestimonyKey
 
 
 def test_ae015_golden_expect_yes():
@@ -15,4 +16,4 @@ def test_ae015_golden_expect_yes():
     result = evaluate_chart(chart)
     assert result["verdict"] == "YES"
     keys = [entry["key"] for entry in result["ledger"]]
-    assert "moon_applying_trine_examiner_sun" in keys
+    assert TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN in keys


### PR DESCRIPTION
## Summary
- Emit `TestimonyKey` members in `extract_testimonies` and propagate enum awareness through aggregator and category router
- Introduce `token_to_string` helper for serialising or logging enum values and use it in evaluation pipeline and rationale builder
- Update tests for enum-based testimonies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15ff18bbc832498d7d6a93583f89b