### PR TITLE
Add explicit polarity helper and rationale pairing with weights

### DIFF
--- a/backend/horary_engine/aggregator.py
+++ b/backend/horary_engine/aggregator.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 
 from typing import Iterable, List, Tuple, Dict, Sequence
 
-from .polarity_weights import (
-    POLARITY_TABLE,
-    WEIGHT_TABLE,
-    Polarity,
-    TestimonyKey,
-)
+from .polarity_weights import POLARITY_TABLE, WEIGHT_TABLE, TestimonyKey
+from .polarity import Polarity
 
 
 def _coerce_tokens(testimonies: Iterable[TestimonyKey | str]) -> Sequence[TestimonyKey]:
@@ -35,8 +31,8 @@ def aggregate(
     treated uniformly via the ``POLARITY_TABLE``. It enforces several
     invariants:
 
-    * polarity: each token must map to ``Polarity.FAVORABLE`` or
-      ``Polarity.UNFAVORABLE``
+    * polarity: each token must map to ``Polarity.POSITIVE`` or
+      ``Polarity.NEGATIVE``
     * monotonicity: weights are non-negative and contributions sum linearly
     * single contribution: duplicate tokens are ignored
     * deterministic order: processing occurs in sorted token order
@@ -58,8 +54,8 @@ def aggregate(
         weight = WEIGHT_TABLE.get(token, 0.0)
         if weight < 0:
             raise ValueError("Weights must be non-negative for monotonicity")
-        delta_yes = weight if polarity is Polarity.FAVORABLE else 0.0
-        delta_no = weight if polarity is Polarity.UNFAVORABLE else 0.0
+        delta_yes = weight if polarity is Polarity.POSITIVE else 0.0
+        delta_no = weight if polarity is Polarity.NEGATIVE else 0.0
         total_yes += delta_yes
         total_no += delta_no
         ledger.append(

--- a/backend/horary_engine/polarity.py
+++ b/backend/horary_engine/polarity.py
@@ -1,0 +1,47 @@
+"""Shared polarity utilities."""
+from __future__ import annotations
+
+from enum import Enum, auto
+from typing import Any
+
+
+class Polarity(Enum):
+    """Categorical polarity used throughout the engine."""
+
+    POSITIVE = auto()
+    NEGATIVE = auto()
+    NEUTRAL = auto()
+
+
+def normalize_polarity(value: Any) -> Polarity:
+    """Normalize arbitrary inputs into a ``Polarity`` member."""
+
+    if isinstance(value, Polarity):
+        return value
+    if isinstance(value, (int, float)):
+        if value > 0:
+            return Polarity.POSITIVE
+        if value < 0:
+            return Polarity.NEGATIVE
+        return Polarity.NEUTRAL
+    text = str(value).strip().lower()
+    if text in {"+", "positive", "favorable"}:
+        return Polarity.POSITIVE
+    if text in {"-", "negative", "unfavorable"}:
+        return Polarity.NEGATIVE
+    return Polarity.NEUTRAL
+
+
+def polarity_sign(polarity: Any) -> str:
+    """Return a user-friendly sign for a polarity value.
+
+    Neutral entries are labeled with ``"0"`` to make their absence of effect
+    explicit to callers.
+    """
+
+    pol = normalize_polarity(polarity)
+    if pol is Polarity.POSITIVE:
+        return "+"
+    if pol is Polarity.NEGATIVE:
+        return "-"
+    return "0"

--- a/backend/horary_engine/polarity_weights.py
+++ b/backend/horary_engine/polarity_weights.py
@@ -2,15 +2,9 @@
 
 from __future__ import annotations
 
-from enum import Enum, auto
+from enum import Enum
 
-
-class Polarity(Enum):
-    """Enum representing whether a testimony helps or harms the question."""
-
-    FAVORABLE = auto()
-    UNFAVORABLE = auto()
-    NEUTRAL = auto()
+from .polarity import Polarity
 
 
 class TestimonyKey(Enum):
@@ -26,9 +20,9 @@ TestimonyKey.__test__ = False
 
 POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     # Favorable Moon applying trine to the examiner (Sun in education questions)
-    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: Polarity.FAVORABLE,
+    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: Polarity.POSITIVE,
     # Example negative testimony
-    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: Polarity.UNFAVORABLE,
+    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: Polarity.NEGATIVE,
 }
 
 WEIGHT_TABLE: dict[TestimonyKey, float] = {

--- a/backend/horary_engine/rationale.py
+++ b/backend/horary_engine/rationale.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from typing import List, Dict
 
-from .polarity_weights import Polarity, TestimonyKey
+from .polarity import Polarity, polarity_sign
+from .polarity_weights import TestimonyKey
 from .utils import token_to_string
 
 
@@ -19,11 +20,9 @@ def build_rationale(
         key = token_to_string(entry.get("key", ""))
         weight = entry.get("weight", 0.0)
         polarity = entry.get("polarity", Polarity.NEUTRAL)
-        if polarity is Polarity.FAVORABLE:
-            sign = "+"
-        elif polarity is Polarity.UNFAVORABLE:
-            sign = "-"
+        sign = polarity_sign(polarity)
+        if sign == "0":
+            result.append(f"{key} ({sign})")
         else:
-            sign = ""
-        result.append(f"{key} {sign}{weight}")
+            result.append(f"{key} ({sign}{weight})")
     return result

--- a/tests/test_aggregator_properties.py
+++ b/tests/test_aggregator_properties.py
@@ -6,7 +6,8 @@ sys.path.append(str(repo_root))
 sys.path.append(str(repo_root / "backend"))
 
 from backend.horary_engine.aggregator import aggregate
-from backend.horary_engine.polarity_weights import TestimonyKey, Polarity
+from backend.horary_engine.polarity_weights import TestimonyKey
+from backend.horary_engine.polarity import Polarity
 
 POS = TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN
 NEG = TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN
@@ -17,7 +18,7 @@ def test_polars_and_monotonicity():
     assert score_pos > 0
     entry_pos = ledger_pos[0]
     assert entry_pos["key"] is POS
-    assert entry_pos["polarity"] is Polarity.FAVORABLE
+    assert entry_pos["polarity"] is Polarity.POSITIVE
     assert entry_pos["delta_yes"] > 0 and entry_pos["delta_no"] == 0
     # Duplicate contributions do not increase score
     score_dup, _ = aggregate([POS, POS])
@@ -30,5 +31,5 @@ def test_polars_and_monotonicity():
     assert score_neg < 0
     entry_neg = ledger_neg[0]
     assert entry_neg["key"] is NEG
-    assert entry_neg["polarity"] is Polarity.UNFAVORABLE
+    assert entry_neg["polarity"] is Polarity.NEGATIVE
     assert entry_neg["delta_no"] > 0 and entry_neg["delta_yes"] == 0

--- a/tests/test_category_router_rationale.py
+++ b/tests/test_category_router_rationale.py
@@ -19,7 +19,7 @@ def test_category_router_toggle_and_rationale():
     chart = build_chart("education")
     result = evaluate_chart(chart)
     assert result["verdict"] == "YES"
-    assert result["rationale"] == ["moon_applying_trine_examiner_sun +1.0"]
+    assert result["rationale"] == ["moon_applying_trine_examiner_sun (+1.0)"]
 
     chart_no = build_chart("finance")
     result_no = evaluate_chart(chart_no)

--- a/tests/test_polarity_sign.py
+++ b/tests/test_polarity_sign.py
@@ -1,0 +1,8 @@
+from backend.horary_engine.polarity import Polarity, polarity_sign
+from backend.horary_engine.rationale import build_rationale
+
+
+def test_polarity_sign_and_rationale_neutral():
+    assert polarity_sign(Polarity.NEUTRAL) == "0"
+    ledger = [{"key": "dummy", "polarity": Polarity.NEUTRAL, "weight": 0.0}]
+    assert build_rationale(ledger) == ["dummy (0)"]


### PR DESCRIPTION
## Summary
- introduce shared `Polarity` enum with `polarity_sign` helper that maps positive, negative and neutral values to `+`, `-` and `0`
- update rationale builder to pair polarity signs with weights and label neutral contributions
- cover polarity helper with unit tests and adjust existing rationale expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1629b5a10832488bf72c9cf718ff2