### PR TITLE
Document reception and refranation rules R015-R020

### DIFF
--- a/docs/rules.yaml
+++ b/docs/rules.yaml
@@ -1,0 +1,43 @@
+features:
+  reception_pair_kind:
+    description: Type of reception between primary significators
+    values:
+      - none
+      - mutual_rulership
+      - mutual_exaltation
+      - mutual_term
+      - mutual_face
+      - mixed_reception
+      - unilateral
+  reception_strength_pair:
+    description: Numeric strength of the reception between significators
+    type: integer
+  house_ruler_reception:
+    description: One significator rules the house of the other
+    type: boolean
+  S1_stations_before_perfection:
+    description: Significator 1 stations before perfecting the aspect (refranation)
+    type: boolean
+  S2_stations_before_perfection:
+    description: Significator 2 stations before perfecting the aspect (refranation)
+    type: boolean
+
+rules:
+  - id: R015
+    condition: reception_pair_kind == 'unilateral'
+    effect: apply_weight(reception_strength_pair, priority=30)
+  - id: R016
+    condition: reception_pair_kind in ['mutual_rulership', 'mutual_exaltation', 'mutual_term', 'mutual_face']
+    effect: apply_weight(reception_strength_pair, priority=90)
+  - id: R017
+    condition: reception_pair_kind == 'mixed_reception'
+    effect: apply_weight(reception_strength_pair, priority=60)
+  - id: R018
+    condition: house_ruler_reception
+    effect: apply_weight(1, priority=40)
+  - id: R019
+    condition: S1_stations_before_perfection
+    effect: apply_weight(-5, priority=80)
+  - id: R020
+    condition: S2_stations_before_perfection
+    effect: apply_weight(-5, priority=80)

--- a/docs/rules_catalog.md
+++ b/docs/rules_catalog.md
@@ -1,0 +1,16 @@
+# Horary Logic Rules Catalog
+
+This catalog enumerates formal rules used by the horary logic engine.
+
+## Receptions and Motion (R015–R020)
+
+| Rule | Condition | Effect | Priority |
+|------|-----------|--------|----------|
+| R015 | `reception_pair_kind == 'unilateral'` | Apply moderate positive weight based on `reception_strength_pair` | 30 |
+| R016 | `reception_pair_kind` in {`mutual_rulership`, `mutual_exaltation`, `mutual_term`, `mutual_face`} | Apply strong positive weight based on `reception_strength_pair` | 90 |
+| R017 | `reception_pair_kind == 'mixed_reception'` | Apply medium positive weight based on `reception_strength_pair` | 60 |
+| R018 | `house_ruler_reception` is true | Grant minor assistance to perfection | 40 |
+| R019 | `S1_stations_before_perfection` is true | Refranation: perfection is prevented, apply strong negative weight | 80 |
+| R020 | `S2_stations_before_perfection` is true | Refranation: perfection is prevented, apply strong negative weight | 80 |
+
+*R015–R017* cover various forms of reception between the primary significators. *R018* captures cases where one significator rules the other's house. *R019* and *R020* address refranation due to either significator stationing before the perfecting aspect.

--- a/docs/rules_index.json
+++ b/docs/rules_index.json
@@ -1,0 +1,8 @@
+{
+  "R015": "reception_pair_kind == 'unilateral'",
+  "R016": "reception_pair_kind in ['mutual_rulership', 'mutual_exaltation', 'mutual_term', 'mutual_face']",
+  "R017": "reception_pair_kind == 'mixed_reception'",
+  "R018": "house_ruler_reception",
+  "R019": "S1_stations_before_perfection",
+  "R020": "S2_stations_before_perfection"
+}


### PR DESCRIPTION
## Summary
- Add rules R015–R020 for receptions, house-ruler reception, and refranation
- Define new features and rule metadata in `rules.yaml` and regenerate rule index
- Document rule details in the rules catalog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1729e43588324a2ab985e55de5f3c