### PR TITLE
Refine reception strength calculation

### DIFF
--- a/tests/test_reception_strength.py
+++ b/tests/test_reception_strength.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+sys.path.append(str(repo_root / "backend"))
+
+from backend.horary_engine.reception import TraditionalReceptionCalculator
+
+def test_reception_strength_min_synergy():
+    calc = TraditionalReceptionCalculator()
+    # One direction exaltation (4), other term (2) -> min=2, synergy+1 => 3
+    assert calc._calculate_reception_strength(["exaltation"], ["term"]) == 3
+
+def test_reception_strength_no_synergy_when_weak():
+    calc = TraditionalReceptionCalculator()
+    # Term vs face -> min=1, no synergy
+    assert calc._calculate_reception_strength(["term"], ["face"]) == 1


### PR DESCRIPTION
## Summary
- Compute mutual reception strength from both directions and add synergy bonus when either side is at least triplicity
- Expose new strength metric to callers and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a17a6133bc8324bac7dcce9643830a