### PR TITLE
feat: detect refranation and frustration

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -103,7 +103,7 @@ confidence:
   
   # Denial confidence levels  
   denial:
-    prohibition: 85
+    frustration: 85
     frustration_retrograde: 75    # configurable instead of automatic NO
     refranation: 80
     abscission: 70


### PR DESCRIPTION
## Summary
- detect upcoming stations before aspect perfection as refranation
- classify third-planet aspect interference as frustration with detailed info
- adjust confidence constants for new frustration rule

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a17d0877c08324974a14a5ec0d9597