### PR TITLE
Implement tiered rule evaluation with priority

### DIFF
--- a/backend/rule_engine.py
+++ b/backend/rule_engine.py
@@ -1,0 +1,44 @@
+"""Rule evaluation utilities implementing tiered priority with first-hit wins."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import rules
+
+# Fixed priority order for rule tiers
+PRIORITY_TIERS = [
+    "validity_gates",
+    "hard_stoppers",
+    "perfection",
+    "special_topics",
+    "moon",
+    "modifiers",
+    "thresholds",
+]
+
+
+def evaluate_rules(candidate_ids: Iterable[str]) -> List[str]:
+    """Return rule IDs selected according to priority tiers.
+
+    Parameters
+    ----------
+    candidate_ids: Iterable[str]
+        Iterable of rule IDs that evaluate to true.
+
+    Returns
+    -------
+    List[str]
+        Ordered list of chosen rule IDs, at most one per tier.
+    """
+    candidates = set(candidate_ids)
+    selected: List[str] = []
+    for tier in PRIORITY_TIERS:
+        tier_rules = sorted(
+            (r for r in rules.RULES if r.get("tier") == tier),
+            key=lambda r: r["id"],
+        )
+        for rule in tier_rules:
+            if rule["id"] in candidates:
+                selected.append(rule["id"])
+                break  # first-hit wins within tier
+    return selected

--- a/backend/rules.py
+++ b/backend/rules.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional, Union
 
 def dynamic_weight() -> float:
     """Example weight function used by some rules.
@@ -11,19 +11,29 @@ def dynamic_weight() -> float:
 
 
 # Rules use a common schema where each rule must provide either a
-# numeric ``weight`` or a callable name via ``weight_fn``.
-#
-# The schema is intentionally simple to keep the rule system flexible
-# while allowing unit tests to validate the structure.
-RULES: List[Dict[str, Optional[str]]] = [
+# numeric ``weight`` or a callable name via ``weight_fn``.  Rules are
+# also grouped into tiers that control evaluation priority in
+# ``rule_engine.evaluate_rules``.
+RuleDict = Dict[str, Union[str, float]]
+
+RULES: List[RuleDict] = [
+    {"id": "V1", "tier": "validity_gates", "description": "Early Ascendant", "weight": 1.0},
+    {"id": "V2", "tier": "validity_gates", "description": "Late Ascendant", "weight": 1.0},
+    {"id": "H1", "tier": "hard_stoppers", "description": "Saturn in 7th", "weight": 1.0},
+    {"id": "H2", "tier": "hard_stoppers", "description": "Void of Course", "weight": 1.0},
+    {"id": "P1", "tier": "perfection", "description": "Direct perfection", "weight": 1.0},
     {
-        "id": "static",
-        "description": "Rule with an inline numeric weight",
-        "weight": 1.0,
-    },
-    {
-        "id": "dynamic",
-        "description": "Rule that resolves its weight via a named function",
+        "id": "P2",
+        "tier": "perfection",
+        "description": "Translation of light",
         "weight_fn": "dynamic_weight",
     },
+    {"id": "S1", "tier": "special_topics", "description": "Education overrides", "weight": 1.0},
+    {"id": "S2", "tier": "special_topics", "description": "Medical exceptions", "weight": 1.0},
+    {"id": "M1", "tier": "moon", "description": "Moon trine Sun", "weight": 1.0},
+    {"id": "M2", "tier": "moon", "description": "Moon square Saturn", "weight": 1.0},
+    {"id": "MOD1", "tier": "modifiers", "description": "Reception boost", "weight": 1.0},
+    {"id": "MOD2", "tier": "modifiers", "description": "Debility penalty", "weight": 1.0},
+    {"id": "T1", "tier": "thresholds", "description": "Dignity threshold", "weight": 1.0},
+    {"id": "T2", "tier": "thresholds", "description": "Speed threshold", "weight": 1.0},
 ]

--- a/tests/test_rule_engine_priority.py
+++ b/tests/test_rule_engine_priority.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+sys.path.append(str(repo_root / "backend"))
+
+from backend.rule_engine import evaluate_rules
+
+
+def test_first_hit_wins_within_tier():
+    result = evaluate_rules(["V2", "V1", "M2", "M1"])
+    assert result == ["V1", "M1"]
+
+
+def test_tier_priority_order():
+    candidates = ["M2", "P1", "V2", "MOD1", "H2", "T2", "S1"]
+    result = evaluate_rules(candidates)
+    assert result == ["V2", "H2", "P1", "S1", "M2", "MOD1", "T2"]


### PR DESCRIPTION
## Summary
- Define rule tiers and assign each rule a tier in `rules.py`
- Add `rule_engine` with fixed priority order and first-hit evaluation
- Test priority ordering and first-hit behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a182ecbc8c8324b4f838d023a04df3